### PR TITLE
fix: 兼容java xxlRpcResponse.getErrorMsg() != null

### DIFF
--- a/admin/struct.go
+++ b/admin/struct.go
@@ -53,7 +53,7 @@ func (Beat) JavaClassName() string {
 
 type XxlRpcResponse struct {
 	RequestId string
-	ErrorMsg  string
+	ErrorMsg  interface{}
 	Result    hessian.Object
 }
 


### PR DESCRIPTION
省去了“写在前面”的解决方案